### PR TITLE
support return raw pb data and add revert func

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -16,15 +16,19 @@ const (
 type PolygonCoordinates [][][2]float64
 type MultiPolygonCoordinates []PolygonCoordinates
 
+type GeometryDefine struct {
+	Coordinates interface{} `json:"coordinates"`
+	Type        string      `json:"type"`
+}
+
+type PropertiesDefine struct {
+	Tzid string `json:"tzid"`
+}
+
 type FeatureItem struct {
-	Geometry struct {
-		Coordinates interface{} `json:"coordinates"`
-		Type        string      `json:"type"`
-	} `json:"geometry"`
-	Properties struct {
-		Tzid string `json:"tzid"`
-	} `json:"properties"`
-	Type string `json:"type"`
+	Geometry   GeometryDefine   `json:"geometry"`
+	Properties PropertiesDefine `json:"properties"`
+	Type       string           `json:"type"`
 }
 
 type BoundaryFile struct {

--- a/convert/revert.go
+++ b/convert/revert.go
@@ -1,0 +1,38 @@
+package convert
+
+import "github.com/ringsaturn/tzf/pb"
+
+func FromPbPolygonToGeoMultipolygon(pbpoly []*pb.Polygon) MultiPolygonCoordinates {
+	res := MultiPolygonCoordinates{}
+	for _, poly := range pbpoly {
+		newGeoPoly := make(PolygonCoordinates, 1)
+		for _, point := range poly.Points {
+			newGeoPoly[0] = append(newGeoPoly[0], [2]float64{float64(point.Lng), float64(point.Lat)})
+		}
+		res = append(res, newGeoPoly)
+	}
+	return res
+}
+
+func RevertItem(input *pb.Timezone) *FeatureItem {
+	return &FeatureItem{
+		Type: FeatureType,
+		Properties: PropertiesDefine{
+			Tzid: input.Name,
+		},
+		Geometry: GeometryDefine{
+			Type:        MultiPolygonType,
+			Coordinates: FromPbPolygonToGeoMultipolygon(input.Polygons),
+		},
+	}
+}
+
+// Revert could convert pb define data to GeoJSON format.
+func Revert(input *pb.Timezones) *BoundaryFile {
+	output := &BoundaryFile{}
+	for _, timezone := range input.Timezones {
+		item := RevertItem(timezone)
+		output.Features = append(output.Features, item)
+	}
+	return output
+}


### PR DESCRIPTION
Will be useful to provider a HTTP server for debug and check in GeoJSON format(paste to https://geojson.io to view in map!)

```go
package main

import (
	"github.com/gin-gonic/gin"
	"github.com/ringsaturn/tzf"
	tzfrel "github.com/ringsaturn/tzf-rel"
	"github.com/ringsaturn/tzf/convert"
	"github.com/ringsaturn/tzf/pb"
	"google.golang.org/protobuf/proto"
)

type TzRequest struct {
	Lng float64 `form:"lng"`
	Lat float64 `form:"lat"`
}

func main() {

	input := &pb.Timezones{}

	// Lite data, about 16.7MB
	dataFile := tzfrel.LiteData

	// Full data, about 83.5MB
	// dataFile := tzfrel.FullData

	if err := proto.Unmarshal(dataFile, input); err != nil {
		panic(err)
	}
	finder, _ := tzf.NewFinderFromPB(input)

	e := gin.Default()
	e.GET("/ping", func(ctx *gin.Context) {
		ctx.String(200, "pong")
	})
	e.GET("/tz", func(ctx *gin.Context) {
		req := &TzRequest{}
		if err := ctx.ShouldBindQuery(req); err != nil {
			ctx.String(400, err.Error())
			return
		}
		tz, err := finder.GetTimezone(req.Lng, req.Lat)
		if err != nil {
			ctx.String(500, err.Error())
			return
		}
		ctx.String(200, tz.Name)
	})
	e.GET("/tz/geojson", func(ctx *gin.Context) {
		req := &TzRequest{}
		if err := ctx.ShouldBindQuery(req); err != nil {
			ctx.String(400, err.Error())
			return
		}
		tz, err := finder.GetTimezone(req.Lng, req.Lat)
		if err != nil {
			ctx.String(500, err.Error())
			return
		}
		ctx.JSON(200, convert.RevertItem(tz))
	})
	e.Run()
}
```
