### PR TITLE
Fix memory leak in tzfpy

### DIFF
--- a/python/tzfpy/__init__.py
+++ b/python/tzfpy/__init__.py
@@ -1,5 +1,5 @@
 import os
-from ctypes import CDLL, POINTER, c_char_p, c_float, c_long
+from ctypes import CDLL, POINTER, c_char_p, c_float, c_long, c_int
 from typing import List
 
 c_lib = CDLL(os.path.join(os.path.dirname(__file__), "tzf.so"))
@@ -15,6 +15,9 @@ _names_counts.restype = c_long
 _names = c_lib.TimezoneNames
 _names.restype = POINTER(c_char_p)
 
+_free = c_lib.FreeChar
+_free.argtypes = [c_char_p]
+_free.restype = c_int
 
 _count = _names_counts()
 
@@ -31,7 +34,11 @@ names = _setup_timezone_names()
 
 
 def get_tz(lng: float, lat: float) -> str:
-    return _get(c_float(lng), c_float(lat)).decode()
+    raw = _get(c_float(lng), c_float(lat))
+    ret = raw.decode()
+    # print(ret)
+    _free(raw)
+    return ret
 
 
 def timezone_names() -> List[str]:
@@ -45,9 +52,9 @@ def timezone_names_counts() -> int:
 if __name__ == "__main__":
     import time
     while True:
-        for i in range(1000):
-            get_tz(116, 39)
-            timezone_names()
-            timezone_names_counts()
-        time.sleep(0.01)
+        # for i in range(1000):
+        get_tz(116, 39)
+        # timezone_names()
+        # timezone_names_counts()
+        time.sleep(1)
     # print(timezone_names())

--- a/python/tzfpy/__init__.py
+++ b/python/tzfpy/__init__.py
@@ -49,13 +49,6 @@ def timezone_names_counts() -> int:
 
 
 if __name__ == "__main__":
-    import time
-
+    print(get_tz(11, 11))
     print(get_tz(116, 39))
-    while True:
-        # for i in range(1000):
-        get_tz(116, 39)
-        timezone_names()
-        timezone_names_counts()
-        time.sleep(0.1)
-    # print(timezone_names())
+    print(timezone_names())

--- a/python/tzfpy/__init__.py
+++ b/python/tzfpy/__init__.py
@@ -1,13 +1,12 @@
 import os
-from ctypes import CDLL, POINTER, c_char_p, c_float, c_long, c_int
+from ctypes import CDLL, POINTER, c_char_p, c_float, c_long, c_int, c_void_p, string_at
 from typing import List
 
 c_lib = CDLL(os.path.join(os.path.dirname(__file__), "tzf.so"))
 
 _get = c_lib.GetTZ
 _get.argtypes = [POINTER(c_float), POINTER(c_float)]
-_get.restype = c_char_p
-
+_get.restype = c_void_p
 
 _names_counts = c_lib.CountTimezoneNames
 _names_counts.restype = c_long
@@ -15,8 +14,9 @@ _names_counts.restype = c_long
 _names = c_lib.TimezoneNames
 _names.restype = POINTER(c_char_p)
 
+# For free mem
 _free = c_lib.FreeChar
-_free.argtypes = [c_char_p]
+_free.argtypes = [c_void_p]
 _free.restype = c_int
 
 _count = _names_counts()
@@ -35,8 +35,7 @@ names = _setup_timezone_names()
 
 def get_tz(lng: float, lat: float) -> str:
     raw = _get(c_float(lng), c_float(lat))
-    ret = raw.decode()
-    # print(ret)
+    ret = string_at(raw).decode()
     _free(raw)
     return ret
 
@@ -51,10 +50,12 @@ def timezone_names_counts() -> int:
 
 if __name__ == "__main__":
     import time
+
+    print(get_tz(116, 39))
     while True:
         # for i in range(1000):
         get_tz(116, 39)
-        # timezone_names()
-        # timezone_names_counts()
-        time.sleep(1)
+        timezone_names()
+        timezone_names_counts()
+        time.sleep(0.1)
     # print(timezone_names())

--- a/python/tzfpy/__init__.py
+++ b/python/tzfpy/__init__.py
@@ -16,23 +16,38 @@ _names = c_lib.TimezoneNames
 _names.restype = POINTER(c_char_p)
 
 
-def get_tz(lng: float, lat: float) -> str:
-    return _get(c_float(lng), c_float(lat)).decode()
+_count = _names_counts()
 
 
-def timezone_names_counts() -> int:
-    return _names_counts()
-
-
-def timezone_names() -> List[str]:
+def _setup_timezone_names() -> List[str]:
     res = _names()
     names = []
-    for i in range(timezone_names_counts()):
+    for i in range(_count):
         names.append(res[i].decode())
     return names
 
 
+names = _setup_timezone_names()
+
+
+def get_tz(lng: float, lat: float) -> str:
+    return _get(c_float(lng), c_float(lat)).decode()
+
+
+def timezone_names() -> List[str]:
+    return names
+
+
+def timezone_names_counts() -> int:
+    return _count
+
+
 if __name__ == "__main__":
-    print(get_tz(11, 11))
-    print(get_tz(116, 39))
-    print(timezone_names())
+    import time
+    while True:
+        for i in range(1000):
+            get_tz(116, 39)
+            timezone_names()
+            timezone_names_counts()
+        time.sleep(0.01)
+    # print(timezone_names())

--- a/python/tzfpy/__init__.py
+++ b/python/tzfpy/__init__.py
@@ -1,5 +1,14 @@
 import os
-from ctypes import CDLL, POINTER, c_char_p, c_float, c_long, c_int, c_void_p, string_at
+from ctypes import (
+    CDLL,
+    POINTER,
+    c_char_p,
+    c_float,
+    c_int,
+    c_long,
+    c_void_p,
+    string_at,
+)
 from typing import List
 
 c_lib = CDLL(os.path.join(os.path.dirname(__file__), "tzf.so"))

--- a/python/tzfpy/main.go
+++ b/python/tzfpy/main.go
@@ -24,11 +24,15 @@ func init() {
 	timezoneCounts = len(finder.TimezoneNames())
 }
 
+// GetTZ for Python calling, please ensure calling [FreeChar] afer got value.
+//
 //export GetTZ
 func GetTZ(lng *C.float, lat *C.float) *C.char {
 	return C.CString(finder.GetTimezoneName(float64(*lng), float64(*lat)))
 }
 
+// FreeChar for other side to free *C.char which come free [GetTZ]
+//
 //export FreeChar
 func FreeChar(input unsafe.Pointer) {
 	C.free(input)
@@ -46,11 +50,15 @@ func goStringSliceToC(stringSlice []string) **C.char {
 	return (**C.char)(cArray)
 }
 
+// NOTE(ringsaturn): this func should only call once since no free mem method for return value.
+//
 //export TimezoneNames
 func TimezoneNames() **C.char {
 	return goStringSliceToC(finder.TimezoneNames())
 }
 
+// NOTE(ringsaturn): this func should only call once since no free mem method for return value.
+//
 //export CountTimezoneNames
 func CountTimezoneNames() C.long {
 	return C.long(timezoneCounts)

--- a/python/tzfpy/main.go
+++ b/python/tzfpy/main.go
@@ -1,6 +1,8 @@
 // TZF's Python binding
 package main
 
+//#cgo LDFLAGS:
+//#include <stdlib.h>
 import "C"
 import (
 	"unsafe"
@@ -24,7 +26,10 @@ func init() {
 
 //export GetTZ
 func GetTZ(lng *C.float, lat *C.float) *C.char {
-	return C.CString(finder.GetTimezoneName(float64(*lng), float64(*lat)))
+	ret := C.CString(finder.GetTimezoneName(float64(*lng), float64(*lat)))
+
+	defer C.free(unsafe.Pointer((ret)))
+	return ret
 }
 
 func goStringSliceToC(stringSlice []string) **C.char {

--- a/python/tzfpy/main.go
+++ b/python/tzfpy/main.go
@@ -26,18 +26,12 @@ func init() {
 
 //export GetTZ
 func GetTZ(lng *C.float, lat *C.float) *C.char {
-	ret := C.CString(finder.GetTimezoneName(float64(*lng), float64(*lat)))
-	return ret
+	return C.CString(finder.GetTimezoneName(float64(*lng), float64(*lat)))
 }
 
 //export FreeChar
-func FreeChar(input *C.char) {
-	// fmt.Println("input", input)
-	ptr := unsafe.Pointer(input)
-	// fmt.Println("ptr", ptr)
-	C.free(ptr)
-	// fmt.Println("d")
-	// runtime.GC()
+func FreeChar(input unsafe.Pointer) {
+	C.free(input)
 }
 
 func goStringSliceToC(stringSlice []string) **C.char {

--- a/python/tzfpy/main.go
+++ b/python/tzfpy/main.go
@@ -27,9 +27,17 @@ func init() {
 //export GetTZ
 func GetTZ(lng *C.float, lat *C.float) *C.char {
 	ret := C.CString(finder.GetTimezoneName(float64(*lng), float64(*lat)))
-
-	defer C.free(unsafe.Pointer((ret)))
 	return ret
+}
+
+//export FreeChar
+func FreeChar(input *C.char) {
+	// fmt.Println("input", input)
+	ptr := unsafe.Pointer(input)
+	// fmt.Println("ptr", ptr)
+	C.free(ptr)
+	// fmt.Println("d")
+	// runtime.GC()
 }
 
 func goStringSliceToC(stringSlice []string) **C.char {


### PR DESCRIPTION
- set timezone counts, names to Python vars, and never calling c_lib
- add free func to free memory after got pointer from Go side, and send it back to Go side to free