### PR TITLE
add option to lookup multiple coordinates from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ longitude values to get the timezone name:
 tzf -lng 116.3883 -lat 39.9289
 ```
 
+Alternatively if you want to look up multiple coordinates efficiently you can
+specify the ordering and pipe them to the tzf command one pair of coordinates
+per line:
+
+```bash
+echo -e "116.3883 39.9289\n116.3883, 39.9289" | tzf -stdin-order lng-lat
+```
+
 ## Data
 
 You can download the original data from

--- a/cmd/tzf/main.go
+++ b/cmd/tzf/main.go
@@ -2,8 +2,13 @@
 package main
 
 import (
+	"bufio"
+	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/ringsaturn/tzf"
 	tzfrellite "github.com/ringsaturn/tzf-rel-lite"
@@ -26,12 +31,76 @@ func init() {
 	}
 }
 
+type StdinOrder int
+
+const (
+	LngLat StdinOrder = iota
+	LatLng
+)
+
 func main() {
 	var lng float64
 	var lat float64
-	flag.Float64Var(&lng, "lng", 116.3883, "longitude")
-	flag.Float64Var(&lat, "lat", 39.9289, "lontitude")
+	var stdinOrder StdinOrder
+	flag.Float64Var(&lng, "lng", 0.0, "Longitude")
+	flag.Float64Var(&lat, "lat", 0.0, "Latitude")
+	flag.Func("stdin-order", "Read multiple coordinates from stdin in given order", func(s string) error {
+		if s == "lng-lat" || s == "lon-lat" {
+			stdinOrder = LngLat
+		} else if s == "lat-lng" || s == "lat-lon" {
+			stdinOrder = LatLng
+		} else {
+			return errors.New("invalid order, must be one of lng-lat, lat-lng")
+		}
+		return nil
+	})
 	flag.Parse()
-
-	fmt.Println(finder.GetTimezoneName(lng, lat))
+	hasLng := false
+	hasLat := false
+	hasStdinOrder := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "lng" {
+			hasLng = true
+		}
+		if f.Name == "lat" {
+			hasLat = true
+		}
+		if f.Name == "stdin-order" {
+			hasStdinOrder = true
+		}
+	})
+	if hasLng != hasLat {
+		fmt.Fprintln(os.Stderr, "Both -lat and -lng must be passed")
+		os.Exit(2)
+	}
+	if (hasLng || hasLat) == hasStdinOrder {
+		fmt.Fprintln(os.Stderr, "Either -{lat/lng} or -stdin-order must be passed")
+		os.Exit(2)
+	}
+	if hasLng || hasLat {
+		fmt.Println(finder.GetTimezoneName(lng, lat))
+		return
+	}
+	if hasStdinOrder {
+		scanner := bufio.NewScanner(bufio.NewReader(os.Stdin))
+		for scanner.Scan() {
+			line := strings.FieldsFunc(scanner.Text(), func(c rune) bool { return c == ' ' || c == '\t' || c == ',' || c == ';' })
+			if len(line) != 2 {
+				panic("Line does not contain two coordinates")
+			}
+			a, err := strconv.ParseFloat(line[0], 64)
+			if err != nil {
+				panic(err)
+			}
+			b, err := strconv.ParseFloat(line[1], 64)
+			if err != nil {
+				panic(err)
+			}
+			lng, lat := a, b
+			if stdinOrder == LatLng {
+				lng, lat = b, a
+			}
+			fmt.Println(finder.GetTimezoneName(lng, lat))
+		}
+	}
 }


### PR DESCRIPTION
Similar to my recent pull request for the Rust version of this library (see https://github.com/ringsaturn/tzf-rs/pull/166) this MR adds the ability to the command line for processing multiple coordinates from stdin to make it faster to look up large amounts of coordinates (instead of having to start up a new process for each coordinate).

It adds the same option to the command line as supported by the Rust version: -stdin-order {lng-lat,lat-lng}. This option is mutually exclusive with providing a longitude and latitude.

I'm less familiar with Go than I am with Rust, so I took this as a opportunity for me to learn a bit more about it and provide feature parity to this version of tzf. Please feel free to provide feedback to improve it!