### PR TITLE
Fix empty result on shared polygon borders

### DIFF
--- a/internal/geom/geom_test.go
+++ b/internal/geom/geom_test.go
@@ -42,7 +42,113 @@ func TestPolygonContainsPoint_OnEdge(t *testing.T) {
 		if poly.ContainsPoint(p) {
 			t.Errorf("expected edge point %v to be outside (strict containment)", p)
 		}
+		if !poly.ContainsPointAllowOnEdge(p) {
+			t.Errorf("expected edge point %v to be inside under the allow-on-edge rule", p)
+		}
 	}
+}
+
+// shiftRing returns ring translated by dx along the x axis.
+func shiftRing(ring []Point, dx float64) []Point {
+	out := make([]Point, len(ring))
+	for i, p := range ring {
+		out[i] = Point{p.X + dx, p.Y}
+	}
+	return out
+}
+
+// TestPolygonContainsPoint_SharedBorder covers two squares sharing the x == 10
+// border: under the strict rule a query on that border belongs to neither,
+// which is how a tiled polygon set grows gaps along its internal edges.
+func TestPolygonContainsPoint_SharedBorder(t *testing.T) {
+	// The dense rings cross minIndexSegments, so both the linear and the
+	// YStripes-indexed code path get exercised.
+	for _, tc := range []struct {
+		name      string
+		left      []Point
+		right     []Point
+		wantIndex bool
+	}{
+		{"linear", square(0, 10), shiftRing(square(0, 10), 10), false},
+		{"indexed", denseSquare(0, 10, 200), shiftRing(denseSquare(0, 10, 200), 10), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			left := NewPolygon(tc.left, nil)
+			right := NewPolygon(tc.right, nil)
+
+			if got := left.extIdx != nil; got != tc.wantIndex {
+				t.Fatalf("YStripes index built = %v, want %v", got, tc.wantIndex)
+			}
+
+			for _, p := range []Point{{10, 5}, {10, 10}, {10, 0}} {
+				if left.ContainsPoint(p) || right.ContainsPoint(p) {
+					t.Errorf("border point %v: expected strict containment to reject both sides", p)
+				}
+				if !left.ContainsPointAllowOnEdge(p) {
+					t.Errorf("border point %v: expected left polygon to claim it", p)
+				}
+				if !right.ContainsPointAllowOnEdge(p) {
+					t.Errorf("border point %v: expected right polygon to claim it", p)
+				}
+			}
+
+			// Points off the border are unaffected by the edge rule.
+			for _, p := range []Point{{5, 5}, {15, 5}, {25, 5}, {10, 25}} {
+				if left.ContainsPoint(p) != left.ContainsPointAllowOnEdge(p) {
+					t.Errorf("point %v: left polygon changed under the edge rule", p)
+				}
+				if right.ContainsPoint(p) != right.ContainsPointAllowOnEdge(p) {
+					t.Errorf("point %v: right polygon changed under the edge rule", p)
+				}
+			}
+		})
+	}
+}
+
+// TestPolygonContainsPoint_AllowOnEdgeHoleBoundary pins the rule to the
+// exterior: a hole's boundary counts as polygon interior either way, so the
+// ring filling the hole and the ring around it both claim it rather than both
+// dropping it.
+func TestPolygonContainsPoint_AllowOnEdgeHoleBoundary(t *testing.T) {
+	poly := NewPolygon(square(0, 10), [][]Point{square(3, 7)})
+	fill := NewPolygon(square(3, 7), nil)
+
+	for _, p := range []Point{{3, 5}, {3, 3}} {
+		if !poly.ContainsPoint(p) || !poly.ContainsPointAllowOnEdge(p) {
+			t.Errorf("hole boundary %v: expected the surrounding polygon to claim it under both rules", p)
+		}
+		if fill.ContainsPoint(p) {
+			t.Errorf("hole boundary %v: expected strict containment to reject the filling polygon", p)
+		}
+		if !fill.ContainsPointAllowOnEdge(p) {
+			t.Errorf("hole boundary %v: expected the filling polygon to claim it under the allow-on-edge rule", p)
+		}
+	}
+
+	// Inside the hole proper stays outside under both rules.
+	if poly.ContainsPoint(Point{5, 5}) || poly.ContainsPointAllowOnEdge(Point{5, 5}) {
+		t.Error("expected a point inside the hole to stay outside under both rules")
+	}
+}
+
+// denseSquare returns a square ring with n extra vertices per side, enough to
+// cross the minimum segment count for building a YStripes index.
+func denseSquare(min, max float64, n int) []Point {
+	step := (max - min) / float64(n)
+	ring := make([]Point, 0, 4*n+1)
+	for i := range n { // left edge, going up
+		ring = append(ring, Point{min, min + step*float64(i)})
+	}
+	for i := range n { // top edge
+		ring = append(ring, Point{min + step*float64(i), max})
+	}
+	for i := range n { // right edge, going down
+		ring = append(ring, Point{max, max - step*float64(i)})
+	}
+	for i := range n { // bottom edge
+		ring = append(ring, Point{max - step*float64(i), min})
+	}
+	return append(ring, ring[0])
 }
 
 func TestPolygonContainsPoint_WithHole(t *testing.T) {
@@ -156,7 +262,7 @@ func BenchmarkContainsPoint_LinearScan(b *testing.B) {
 	p := Point{1, 1}
 	b.ResetTimer()
 	for range b.N {
-		ringContainsPoint(r, nil, p) // nil index → linear scan
+		ringContainsPoint(r, nil, p, false) // nil index → linear scan
 	}
 }
 

--- a/internal/geom/pip.go
+++ b/internal/geom/pip.go
@@ -110,15 +110,15 @@ func raycastSeg(a, b, p Point) raycastResult {
 	return raycastResult{}
 }
 
-// ringContainsPoint reports whether p is strictly inside ring r using the
-// even-odd ray-casting rule.  Points on the ring boundary return false.
+// ringContainsPoint reports whether p is inside ring r using the even-odd
+// ray-casting rule.  A point on the ring boundary returns allowOnEdge.
 // p must be in the ring's storage space (degrees for float64 rings,
 // 1e5-scaled for int32 rings); segment endpoints are converted to float64 in
 // registers, so the raycast itself is identical for both storage types.
 //
 // When idx is non-nil, only the candidate segments returned by the YStripes
 // index are examined; otherwise all n segments are checked linearly.
-func ringContainsPoint[T Coord](r RingOf[T], idx *yStripesIndex, p Point) bool {
+func ringContainsPoint[T Coord](r RingOf[T], idx *yStripesIndex, p Point, allowOnEdge bool) bool {
 	n := len(r)
 	if n < 3 {
 		return false
@@ -132,7 +132,7 @@ func ringContainsPoint[T Coord](r RingOf[T], idx *yStripesIndex, p Point) bool {
 			j := (i + 1) % n
 			res := raycastSeg(segPoint(r[i]), segPoint(r[j]), p)
 			if res.on {
-				inside = false
+				inside = allowOnEdge
 				return false // stop
 			}
 			if res.inside {
@@ -148,7 +148,7 @@ func ringContainsPoint[T Coord](r RingOf[T], idx *yStripesIndex, p Point) bool {
 		j := (i + 1) % n
 		res := raycastSeg(segPoint(r[i]), segPoint(r[j]), p)
 		if res.on {
-			return false
+			return allowOnEdge
 		}
 		if res.inside {
 			inside = !inside

--- a/internal/geom/polygon.go
+++ b/internal/geom/polygon.go
@@ -92,19 +92,41 @@ func newPolygonOf[T Coord](exterior []PointOf[T], holes [][]PointOf[T], scale fl
 }
 
 // ContainsPoint reports whether the degree-space point p lies strictly inside
-// the polygon: inside the exterior ring and outside all hole rings. Points on
-// a ring boundary return false.
+// the polygon: inside the exterior ring and outside all hole rings. A point on
+// the exterior boundary returns false.
+//
+// Use [PolygonOf.ContainsPointAllowOnEdge] when the boundary should belong to
+// the polygon — for example when adjacent polygons tile a plane and a query on
+// a shared edge must not fall through the crack between them.
 func (poly *PolygonOf[T]) ContainsPoint(p Point) bool {
+	return poly.containsPoint(p, false)
+}
+
+// ContainsPointAllowOnEdge is like [PolygonOf.ContainsPoint], but a point on
+// the exterior boundary returns true.
+//
+// For a set of polygons sharing borders this makes the boundary belong to every
+// polygon that touches it, so no query can land in a gap. The flip side is that
+// a shared edge matches more than one polygon; callers that need a single
+// answer must break the tie themselves.
+func (poly *PolygonOf[T]) ContainsPointAllowOnEdge(p Point) bool {
+	return poly.containsPoint(p, true)
+}
+
+// containsPoint applies allowOnEdge to the exterior ring only. Hole rings are
+// always tested with allowOnEdge = false, so a point on a hole's boundary
+// counts as not in the hole, i.e. inside the polygon under either rule.
+func (poly *PolygonOf[T]) containsPoint(p Point, allowOnEdge bool) bool {
 	sp := Point{X: p.X * poly.scale, Y: p.Y * poly.scale}
 	if sp.X < float64(poly.min.X) || sp.X > float64(poly.max.X) ||
 		sp.Y < float64(poly.min.Y) || sp.Y > float64(poly.max.Y) {
 		return false
 	}
-	if !ringContainsPoint(poly.exterior, poly.extIdx, sp) {
+	if !ringContainsPoint(poly.exterior, poly.extIdx, sp, allowOnEdge) {
 		return false
 	}
 	for i, h := range poly.holes {
-		if ringContainsPoint(h, poly.holeIdxs[i], sp) {
+		if ringContainsPoint(h, poly.holeIdxs[i], sp, false) {
 			return false
 		}
 	}

--- a/tzf.go
+++ b/tzf.go
@@ -45,7 +45,12 @@ type tzitem[T geom.Coord] struct {
 
 func (i *tzitem[T]) ContainsPoint(p geom.Point) bool {
 	for _, poly := range i.polys {
-		if poly.ContainsPoint(p) {
+		// Timezone polygons tile the globe, so a query that lands exactly on a
+		// shared border must belong to both neighbours rather than to neither.
+		// The nautical zones make this easy to hit: their borders sit on whole
+		// meridians (7.5, 22.5, ...), which is exactly the kind of coordinate
+		// people type by hand.
+		if poly.ContainsPointAllowOnEdge(p) {
 			return true
 		}
 	}

--- a/tzf_border_test.go
+++ b/tzf_border_test.go
@@ -1,0 +1,85 @@
+// Regression tests for https://github.com/ringsaturn/tzf-rs/issues/207:
+// a query landing exactly on a shared polygon border used to match neither
+// neighbour and return an empty result.
+
+package tzf_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/ringsaturn/tzf"
+)
+
+func TestNauticalBorderIsNotAGap(t *testing.T) {
+	f, err := tzf.NewDefaultFinder()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The nautical zones are 15-degree-wide strips, so their borders sit on
+	// whole meridians. The two coordinates from the issue report:
+	for _, tc := range []struct {
+		lng, lat float64
+		want     []string
+	}{
+		{7.5, 54.5, []string{"Etc/GMT", "Etc/GMT-1"}},
+		{-22.5, 54.5, []string{"Etc/GMT+1", "Etc/GMT+2"}},
+	} {
+		if got := f.GetTimezoneName(tc.lng, tc.lat); got == "" {
+			t.Errorf("GetTimezoneName(%v, %v) is empty", tc.lng, tc.lat)
+		}
+		// Both sides of the border claim the point.
+		got, err := f.GetTimezoneNames(tc.lng, tc.lat)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("GetTimezoneNames(%v, %v) = %v, want %v", tc.lng, tc.lat, got, tc.want)
+		}
+	}
+}
+
+func TestBorderNeighboursStillResolveToOneSideEach(t *testing.T) {
+	f, err := tzf.NewDefaultFinder()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		lng, lat float64
+		want     string
+	}{
+		{7.4999, 54.5, "Etc/GMT"},
+		{7.5001, 54.5, "Etc/GMT-1"},
+		{-22.4999, 54.5, "Etc/GMT+1"},
+		{-22.5001, 54.5, "Etc/GMT+2"},
+	} {
+		if got := f.GetTimezoneName(tc.lng, tc.lat); got != tc.want {
+			t.Errorf("GetTimezoneName(%v, %v) = %q, want %q", tc.lng, tc.lat, got, tc.want)
+		}
+	}
+}
+
+// TestGlobalGridHasNoHoles sweeps the whole globe at 1 degree. Every point used
+// to miss on the 24 nautical meridians (2753 empty results); nothing may miss
+// now.
+func TestGlobalGridHasNoHoles(t *testing.T) {
+	f, err := tzf.NewDefaultFinder()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var empty [][2]float64
+	for lng := -179.5; lng <= 179.5; lng += 1.0 {
+		for lat := -89.5; lat <= 89.5; lat += 1.0 {
+			if f.GetTimezoneName(lng, lat) == "" {
+				empty = append(empty, [2]float64{lng, lat})
+			}
+		}
+	}
+
+	if len(empty) != 0 {
+		t.Errorf("%d empty results, first few: %v", len(empty), empty[:min(len(empty), 10)])
+	}
+}


### PR DESCRIPTION
ringContainsPoint reports a point lying exactly on a ring as outside, so a query landing on a border between two timezones matched neither of them and returned "". The nautical zones make this easy to hit: they are 15-degree-wide strips whose borders sit on whole meridians (7.5, 22.5, ...), exactly the kind of coordinate people type by hand.

Thread allowOnEdge through ringContainsPoint and add PolygonOf.ContainsPointAllowOnEdge, which tzitem.ContainsPoint now uses, so a border belongs to both neighbours instead of neither. ContainsPoint keeps the previous strict behaviour, and the rule applies to the exterior ring only: hole rings stay at allowOnEdge = false, so a hole's boundary counts as polygon interior under either rule and the ring filling the hole also claims it. internal/polyf, which only backs preindexexclude, is left on strict containment.

Measured on a global 1-degree grid (lat/lng at .5 offsets): 2753 of 64800 queries returned "" before, all of them on the 24 nautical meridians; 0 do now. Every non-border result is unchanged and the DefaultFinder benchmarks show no p50 movement (edge 542-583 ns, random world cities 208 ns, GetTimezoneNames 500 ns before and after).

This is the Go-side counterpart of ringsaturn/tzf-rs#207.