### PR TITLE
Fix go get failure caused by invalid orb version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,26 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Test external module consumption
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo_root="$PWD"
+          consumer_dir="$(mktemp -d)"
+          trap 'rm -rf "$consumer_dir"' EXIT
+          cd "$consumer_dir"
+          go mod init example.com/tzf-consumer
+          go mod edit -replace="github.com/ringsaturn/tzf=$repo_root"
+          printf '%s\n' \
+            'package main' \
+            '' \
+            'import _ "github.com/ringsaturn/tzf"' \
+            '' \
+            'func main() {}' \
+            > main.go
+          go mod tidy
+          go test ./...
+
       - run: ls -al
 
       - name: golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ringsaturn/tzf
 go 1.25.0
 
 require (
-	github.com/paulmach/orb v0.14.0
+	github.com/paulmach/orb v0.13.0
 	github.com/ringsaturn/go-cities.json v0.6.13
 	github.com/ringsaturn/tzf-dist v0.0.2026-c-fix1
 	github.com/tidwall/rtree v1.10.0
@@ -14,3 +14,5 @@ require (
 require github.com/tidwall/geoindex v1.7.0 // indirect
 
 replace github.com/paulmach/orb => github.com/ringsaturn/orb v0.14.0
+
+retract v1.2.4 // requires the nonexistent github.com/paulmach/orb v0.14.0


### PR DESCRIPTION
## Summary

- require the existing upstream `github.com/paulmach/orb v0.13.0`
- keep the local replacement to `github.com/ringsaturn/orb v0.14.0`
- retract `tzf v1.2.4`
- test importing tzf from a separate temporary Go module

## Root cause

The `v1.2.4` module requires `github.com/paulmach/orb v0.14.0`, which does not exist upstream. The replacement works while tzf is the main module, but Go ignores replacement directives from dependency modules. External consumers therefore try to resolve the nonexistent upstream version.

## Impact

External consumers can resolve tzf without adding their own replacement directive. Builds inside this repository continue to use the MongoDB-free fork.

## Validation

The new CI step creates a temporary consumer module, replaces only tzf with the checkout, runs `go mod tidy`, and compiles the consumer. This reproduces dependency resolution with tzf as a dependency.

Fixes #217
